### PR TITLE
minor update

### DIFF
--- a/common-tracking-params.txt
+++ b/common-tracking-params.txt
@@ -32,6 +32,6 @@ mkrid
 campid
 toolid
 customid
-igshid
+igsh*
 si
 sms_*

--- a/common-tracking-params.txt
+++ b/common-tracking-params.txt
@@ -35,3 +35,9 @@ customid
 igsh*
 si
 sms_*
+WT.mc_id
+WT.nav
+campaign_id
+hootPostID
+wprov
+__s


### PR DESCRIPTION
made the instagram tracking param less specific since they now also use "igsh" and added a few from [this thread](https://webmasters.stackexchange.com/questions/109914/is-there-a-set-of-well-known-tracking-parameters-besides-utm)